### PR TITLE
Avoid multiple line break

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -51,6 +51,6 @@ gulp.task('watch', function () {
   gulp.watch(paths.watch, ['test']);
 });
 
-gulp.task('default', ['test']);
 gulp.task('test', ['lint', <% if (istanbulModule) { %>'istanbul'<% } else { %>'mocha'<% } %>]);
 <% if (releaseModule) { %>gulp.task('release', ['bump']);<% } %>
+gulp.task('default', ['test']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,6 @@ gulp.task('watch', function () {
   gulp.watch(paths.watch, ['istanbul']);
 });
 
-gulp.task('default', ['test']);
 gulp.task('test', ['lint', 'istanbul']);
 gulp.task('release', ['bump']);
+gulp.task('default', ['test']);


### PR DESCRIPTION
At initial prompt, I don't choice release module, then I met
gulp-jscs 'Multiple line break error', so I replace gulp task order temporarily.
