### PR TITLE
Remove deprecated gulp.run()

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -46,8 +46,7 @@ gulp.task('bump', ['test'], function () {
     .pipe(gulp.dest('./'));
 });<% } %>
 
-gulp.task('watch', function () {
-  gulp.run('test');
+gulp.task('watch', ['test'], function () {
   gulp.watch(paths.watch, ['test']);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,8 +40,7 @@ gulp.task('bump', ['test'], function () {
     .pipe(gulp.dest('./'));
 });
 
-gulp.task('watch', function () {
-  gulp.run('istanbul');
+gulp.task('watch', ['istanbul'], function () {
   gulp.watch(paths.watch, ['istanbul']);
 });
 


### PR DESCRIPTION
I met this warning:
gulp.run() has been deprecated. Use task dependencies or gulp.watch task
triggering instead.

See below:
https://github.com/gulpjs/gulp/blob/master/docs/recipes/running-tasks-in-series.md
