### PR TITLE
Use gulp-plumber for catching jscs error, like catching mocha error

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -13,6 +13,7 @@ var paths = {
 gulp.task('lint', function () {
   return gulp.src(paths.lint)
     .pipe(plugins.jshint('.jshintrc'))<% if (jscsModule) { %>
+    .pipe(plugins.plumber())
     .pipe(plugins.jscs())<% } %>
     .pipe(plugins.jshint.reporter('jshint-stylish'));
 });<% if (istanbulModule) { %>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ var paths = {
 gulp.task('lint', function () {
   return gulp.src(paths.lint)
     .pipe(plugins.jshint('.jshintrc'))
+    .pipe(plugins.plumber())
     .pipe(plugins.jscs())
     .pipe(plugins.jshint.reporter('jshint-stylish'));
 });


### PR DESCRIPTION
If jscs raise error, then plumber catches this.
