### PR TITLE
Use module.exports instead of exports

### DIFF
--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -15,7 +15,7 @@ $ npm install --save <%= slugname %>
 
 ```javascript
 var <%= safeSlugname %> = require('<%= slugname %>');
-<%= safeSlugname %>.awesome(); // "awesome"
+<%= safeSlugname %>(); // "awesome"
 ```
 
 ## API

--- a/app/templates/example/simple.js
+++ b/app/templates/example/simple.js
@@ -10,4 +10,4 @@
 
 var <%= safeSlugname %> = require('../');
 
-<%= safeSlugname %>.awesome(); // "awesome"
+<%= safeSlugname %>(); // "awesome"

--- a/app/templates/lib/name.js
+++ b/app/templates/lib/name.js
@@ -8,6 +8,6 @@
 
 'use strict';
 
-exports.awesome = function() {
+module.exports = function() {
   return 'awesome';
 };

--- a/app/templates/test/name_test.js
+++ b/app/templates/test/name_test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var <%= safeSlugname %> = require('../lib/<%= slugname %>.js');
+var <%= safeSlugname %> = require('../');
 var assert = require('should');
 
 describe('<%= safeSlugname %>', function () {
 
   it('should be awesome', function () {
-    <%= safeSlugname %>.awesome().should.equal('awesome');
+    <%= safeSlugname %>().should.equal('awesome');
   });
 
 });


### PR DESCRIPTION
Use the more common `module.exports` as default to reduce initial changes.
