### PR TITLE
add jscs option: validateIndentation

### DIFF
--- a/app/templates/jscs.json
+++ b/app/templates/jscs.json
@@ -11,6 +11,7 @@
   "disallowKeywordsOnNewLine": ["else"],
   "disallowTrailingWhitespace": true,
   "requireLineFeedAtFileEnd": true,
+  "validateIndentation": 2,
   "validateJSDoc": {
     "checkParamNames": true,
     "requireParamTypes": true


### PR DESCRIPTION
Since jshint drop the support for indent validation we should use jscs instead.
See: [JSHint release 2.5.0](https://github.com/jshint/jshint/releases/tag/2.5.0) and [JSHint 3 plans](http://www.jshint.com/blog/jshint-3-plans/)
