### PR TITLE
Use travis container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 env: CI=true
+sudo: false
 node_js:
   - '0.10'
 after_script:

--- a/app/templates/_travis.yml
+++ b/app/templates/_travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 env: CI=true
+sudo: false
 node_js:
   - '0.10'<% if (coverallsModule) { %>
 after_script:


### PR DESCRIPTION
Jobs running on container-based infrastructure:
- start up faster
- allow the use of caches for public repositories
- disallow the use of sudo, setuid and setgid executables

http://docs.travis-ci.com/user/workers/container-based-infrastructure/
